### PR TITLE
Update package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 	],
 	"exports": {
 		".": {
+			"default": "./dist/index.js",
 			"svelte": "./dist/index.js"
 		}
 	},


### PR DESCRIPTION
Not having a default field throws errors while bundling in Vite. The proposed resolution is to include a "default" field as well.